### PR TITLE
Add missing auth_implementation to Lyric config if needed

### DIFF
--- a/homeassistant/components/lyric/__init__.py
+++ b/homeassistant/components/lyric/__init__.py
@@ -66,6 +66,11 @@ async def async_setup(hass, config):
 
 async def async_setup_entry(hass: HomeAssistantType, entry: ConfigEntry) -> bool:
     """Set up Lyric from a config entry."""
+    if "auth_implementation" not in entry.data:
+        hass.config_entries.async_update_entry(
+            entry, data={**entry.data, "auth_implementation": DOMAIN}
+        )
+
     implementation = await config_entry_oauth2_flow.async_get_config_entry_implementation(
         hass, entry
     )


### PR DESCRIPTION
Fix for [my comment](https://github.com/home-assistant/home-assistant/pull/23015#issuecomment-554001083) in home-assistant/home-assistant#23015.

I realized that the configuration has to be upgraded to use the new flow after looking at the changes in home-assistant/home-assistant#27727.

May not be needed because the Lyric component hasn't been merged yet, so there's not much to upgrade officially, but I'm sure there will be more users who will run into this problem! :)